### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ npm i tailwindcss-react-aria-components
 npm i @tailwindcss/container-queries
 # if you want to use the HoverCard component
 npm i @floating-ui/react
+# If you want to use the Multi-Select component
+npm i react-stately
+# If you want to use the AlertDialog, Separator or VisuallyHidden component
+npm i react-aria
 ```
 
 3. Edit your tailwind.config.js file using [./tailwind.config.js](./tailwind.config.js)


### PR DESCRIPTION
Added a couple more dependencies to the list since running a build based on the current set of components returns errors e.g _"Cannot find module 'react-aria' or its corresponding type declarations."_

I would _assume_ tree-shaking would not include them in a production build. So it may actually be simpler to include them all, _regardless_ of whether using the components that make use of them.