### PR TITLE
Add an offset to the text link underline

### DIFF
--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -50,7 +50,7 @@ export function TextLink(props: LinkProps) {
   return (
     <Link
       {...props}
-      className={composeTailwindRenderProps(props.className, 'underline')}
+      className={composeTailwindRenderProps(props.className, 'underline underline-offset-4')}
     />
   );
 }


### PR DESCRIPTION
It looks a bit nicer for a text link to have its underline slightly offset (Shadcn etc. do)